### PR TITLE
Change license from other to MPL-2.0

### DIFF
--- a/text-manipulate.cabal
+++ b/text-manipulate.cabal
@@ -10,7 +10,7 @@ copyright:             Copyright (c) 2014-2015 Brendan Hay
 category:              Data, Text
 build-type:            Simple
 extra-source-files:    README.md
-cabal-version:         >= 1.10
+cabal-version:         >= 1.20.0.0
 
 description:
     Manipulate identifiers and structurally non-complex pieces

--- a/text-manipulate.cabal
+++ b/text-manipulate.cabal
@@ -2,7 +2,7 @@ name:                  text-manipulate
 version:               0.2.0.1
 synopsis:              Case conversion, word boundary manipulation, and textual subjugation.
 homepage:              https://github.com/brendanhay/text-manipulate
-license:               OtherLicense
+license:               MPL-2.0
 license-file:          LICENSE
 author:                Brendan Hay
 maintainer:            Brendan Hay <brendan.g.hay@gmail.com>


### PR DESCRIPTION
Hi, this change will make it easier for people to check their dependencies.

I use this command to check my dependencies for their licenses.
`stack ls dependencies --license --no-include-base | egrep -v "BSD2|BSD3|MIT|Apache|BSD-3"`

This package shows up as OtherLicense but typerep-map shows up as `MPL-2.0`.